### PR TITLE
Too loose filter, fixes #6

### DIFF
--- a/GpoToDsc/functions/Export-G2DPesterSuite.ps1
+++ b/GpoToDsc/functions/Export-G2DPesterSuite.ps1
@@ -41,26 +41,26 @@ function Export-G2DPesterSuite
         {
             $null = New-Item -ItemType Directory -Path $Path -Force
         }
+
+        if (-not (Test-Path $Path))
+        {
+            Stop-PSFFunction -Message "Skipping Pester export because $Path is not present and -Force has not been used." -EnableException $true
+        }
     }
     
     process
-    {
-        if (-not (Test-Path $Path))
-        {
-            Write-PSFMessage "Skipping configuration because $Path is not present and -Force has not been used."
-            break
-        }
-        
+    {        
         if ($Configuration.ValidationType -ne 'Pester')
         {
             Write-PSFMessage "Skipping configuration because $($Configuration.ConfigurationName) is not of type Pester"
-            break
+            return
         }
 
         if ($PSCmdlet.ShouldProcess($Configuration.ConfigurationName, 'Export validation'))
         {
             $scriptName = Join-Path -Path $Path -ChildPath "$($Configuration.ConfigurationName).tests.ps1"
             $Configuration | Set-Content -Path $scriptName
+            Get-Item -Path $scriptName
         }
     }
 }

--- a/GpoToDsc/functions/Export-G2DPesterSuite.ps1
+++ b/GpoToDsc/functions/Export-G2DPesterSuite.ps1
@@ -49,7 +49,7 @@ function Export-G2DPesterSuite
     }
     
     process
-    {        
+    {
         if ($Configuration.ValidationType -ne 'Pester')
         {
             Write-PSFMessage "Skipping configuration because $($Configuration.ConfigurationName) is not of type Pester"

--- a/GpoToDsc/functions/Export-G2DValidation.ps1
+++ b/GpoToDsc/functions/Export-G2DValidation.ps1
@@ -41,20 +41,19 @@ function Export-G2DValidation
         {
             $null = New-Item -ItemType Directory -Path $Path -Force
         }
+
+        if (-not (Test-Path $Path))
+        {
+            Stop-PSFFunction -Message "Skipping MOF export because $Path is not present and -Force has not been used." -EnableException $true
+        }
     }
     
     process
     {
-        if (-not (Test-Path $Path))
-        {
-            Write-PSFMessage "Skipping configuration because $Path is not present and -Force has not been used."
-            break
-        }
-
         if ($Configuration.ValidationType -ne 'Dsc')
         {
             Write-PSFMessage "Skipping configuration because $($Configuration.ConfigurationName) is not of type DSC"
-            break
+            return
         }
         
         $configurationScript = [scriptblock]::Create($Configuration.ToString())

--- a/GpoToDsc/functions/Get-G2DObjectFromPolicyRulesFile.ps1
+++ b/GpoToDsc/functions/Get-G2DObjectFromPolicyRulesFile.ps1
@@ -75,7 +75,7 @@ function Get-G2DObjectFromPolicyRulesFile
                     PolicyName   = $policyName
                 }
 
-                $existingItem = $resultList | Where-Object -FilterScript { 
+                $existingItem = $resultList | Where-Object -FilterScript {
                     $_.ObjectType -eq 'RegistryItem' -and ($_.Key -eq $regKey -and $_.ValueName -eq $(Split-Path -Leaf -Path $split1[0]))
                 }
 

--- a/GpoToDsc/functions/Get-G2DObjectFromPolicyRulesFile.ps1
+++ b/GpoToDsc/functions/Get-G2DObjectFromPolicyRulesFile.ps1
@@ -75,7 +75,9 @@ function Get-G2DObjectFromPolicyRulesFile
                     PolicyName   = $policyName
                 }
 
-                $existingItem = $resultList | Where-Object -FilterScript { $_.ObjectType -eq 'RegistryItem' -and $_.Key -eq $regKey }
+                $existingItem = $resultList | Where-Object -FilterScript { 
+                    $_.ObjectType -eq 'RegistryItem' -and ($_.Key -eq $regKey -and $_.ValueName -eq $(Split-Path -Leaf -Path $split1[0]))
+                }
 
                 if ($null -ne $existingItem)
                 {


### PR DESCRIPTION
Fixes #6 when a differently named value was configured under the same registry key.